### PR TITLE
Améliorations de syntaxe de code C#

### DIFF
--- a/Assets/Scripts/Com.Kearny.Shooter/Guns/FireMode.cs
+++ b/Assets/Scripts/Com.Kearny.Shooter/Guns/FireMode.cs
@@ -1,5 +1,9 @@
 namespace Com.Kearny.Shooter.Guns
 {
+    /// <summary>
+    /// C'est une bonne pratique de mettre une valeur numérique à tes éléments de ton énumérations.
+    /// Et tu peux utiliser les enum flagger pour faire des combinaison binaires de valeur autorisés ou non.
+    /// </summary>
     public enum FireMode
     {
         Auto,

--- a/Assets/Scripts/Com.Kearny.Shooter/Guns/Gun.cs
+++ b/Assets/Scripts/Com.Kearny.Shooter/Guns/Gun.cs
@@ -2,17 +2,24 @@ using UnityEngine;
 
 namespace Com.Kearny.Shooter.Guns
 {
+    // J'ai ici l'impression que ta classe représente plus une arme à feu en général plus qu'un pistolet vu que tu as une classe enfant Pistol.
+    // Pourquoi ne pas renommer cette classe Weapon ou FireArm au pire
     public abstract class Gun : MonoBehaviour
     {
         protected abstract FireMode FireMode { get; set; }
+        public float MsBetweenShots { get; set; } = 100;
+        public float MuzzleVelocity { get; set; } = 35;
+        public Transform Muzzle { get; set; }
+        public Projectile Projectile { get; set; }
+        public Transform Shell { get; set; }
+        public Transform ShellEjection { get; set; }
 
-        public Transform muzzle;
-        public Projectile projectile;
-        public float msBetweenShots = 100;
-        public float muzzleVelocity = 35;
-
-        public Transform shell;
-        public Transform shellEjection;
+        /// <summary>
+        /// Vérifie que l'arme peut utiliser le mode de tir : <paramref name="fireModeToCheck"/>
+        /// </summary>
+        /// <param name="fireModeToCheck">Le mode de tir à appliquer à l'arme.</param>
+        /// <returns>Vrai si le mode demandé peut être utilisé par l'arme; Faux sinon.</returns>
+        protected abstract bool IsFireModeAllow(FireMode fireModeToCheck);
 
         private MuzzleFlash _muzzleFlash;
 
@@ -21,12 +28,12 @@ namespace Com.Kearny.Shooter.Guns
         private bool _triggerReleasedSinceLastShot = true;
         private int _shotsRemainingInBurst;
         
-        private const int BurstCount = 3;
+        private const int BURST_COUNT = 3;
 
         private void Start()
         {
             _muzzleFlash = GetComponent<MuzzleFlash>();
-            _shotsRemainingInBurst = BurstCount;
+            _shotsRemainingInBurst = BURST_COUNT;
         }
 
         private void Shoot()
@@ -47,11 +54,11 @@ namespace Com.Kearny.Shooter.Guns
                     return;
             }
 
-            _nextShotTime = Time.time + msBetweenShots / 1000;
-            var newProjectile = Instantiate(projectile, muzzle.position, muzzle.rotation);
-            newProjectile.SetSpeed(muzzleVelocity);
+            _nextShotTime = Time.time + MsBetweenShots / 1000;
+            var newProjectile = Instantiate(Projectile, Muzzle.position, Muzzle.rotation);
+            newProjectile.SetSpeed(MuzzleVelocity);
 
-            Instantiate(shell, shellEjection.position, shellEjection.rotation);
+            Instantiate(Shell, ShellEjection.position, ShellEjection.rotation);
 
             _muzzleFlash.Activate();
         }
@@ -65,7 +72,7 @@ namespace Com.Kearny.Shooter.Guns
         public void OnTriggerRelease()
         {
             _triggerReleasedSinceLastShot = true;
-            _shotsRemainingInBurst = BurstCount;
+            _shotsRemainingInBurst = BURST_COUNT;
         }
     }
 }

--- a/Assets/Scripts/Com.Kearny.Shooter/Guns/GunController.cs
+++ b/Assets/Scripts/Com.Kearny.Shooter/Guns/GunController.cs
@@ -18,6 +18,7 @@ namespace Com.Kearny.Shooter.Guns
 
         private void Update()
         {
+            // Si aucune arme n'est équipée alors on ne fait rien.
             if (!_isGunEquipped) return;
 
             if (Input.GetButton("Fire1"))
@@ -31,9 +32,17 @@ namespace Com.Kearny.Shooter.Guns
             }
         }
 
+        /// <summary>
+        /// Equipe une arme 
+        /// </summary>
+        /// <param name="gunToEquip"></param>
         public void EquipGun(Gun gunToEquip)
         {
-            if (equippedGun != null)
+            // Ici tu pourrais rajouter une propriété dans ton entité Gun afin de ne pas recréer ton objet Gun systématiquement.
+            // Ce que je vois ici, c'est que si tu as un pistolet d'équiper et que tu changes pour un fusil d'assaut c'est ok.
+            // Mais si tu changes d'armes pour en fait sélectionner la même, est-ce vraiment utile de forcer le jeu à la recharger ?
+            // Donc tu pourrais rajouter une identifiant unique sur chaque arme que tu crééeras pour que si le joueur essaye d'équiper uen arme qu'il a déjà en main ça ne la réinstancie pas.
+            if (equippedGun != null /* && equippedGun.uniqueIdentifier != gunToEquip.uniqueIdentifier*/)
             {
                 Destroy(equippedGun.gameObject);
             }

--- a/Assets/Scripts/Com.Kearny.Shooter/Guns/Pistol.cs
+++ b/Assets/Scripts/Com.Kearny.Shooter/Guns/Pistol.cs
@@ -1,7 +1,19 @@
+using System;
+
 namespace Com.Kearny.Shooter.Guns
 {
     public class Pistol : Gun
     {
         protected override FireMode FireMode { get; set; } = FireMode.SemiAuto;
+
+        /// <summary>
+        /// Vérifie que l'arme peut utiliser le mode de tir : <paramref name="fireModeToCheck"/>
+        /// </summary>
+        /// <param name="fireModeToCheck">Le mode de tir à appliquer à l'arme.</param>
+        /// <returns>Vrai si le mode demandé est <see cref="FireMode.SemiAuto"/>; Faux sinon.</returns>
+        protected override bool IsFireModeAllow(FireMode fireModeToCheck)
+        {
+            return fireModeToCheck == FireMode.SemiAuto;
+        }
     }
 }

--- a/Assets/Scripts/Com.Kearny.Shooter/Guns/Projectile.cs
+++ b/Assets/Scripts/Com.Kearny.Shooter/Guns/Projectile.cs
@@ -9,15 +9,13 @@ namespace Com.Kearny.Shooter.Guns
 
         private float _speed;
 
-        private const float Damage = 1;
-
-        private const float Lifetime = 3;
-
-        private const float SkinWidth = .1f;
+        private const float DAMAGE = 1;
+        private const float LIFETIME = 3;
+        private const float SKIN_WIDTH = .1f;
 
         private void Start()
         {
-            Destroy(gameObject, Lifetime);
+            Destroy(gameObject, LIFETIME);
 
             var initialCollisions = Physics.OverlapSphere(transform.position, .1f, collisionMask);
             if (initialCollisions.Length > 0)
@@ -26,6 +24,7 @@ namespace Com.Kearny.Shooter.Guns
             }
         }
 
+        // Quel intérêt de faire une méthode qui fait le travail d'un setter ? Pour quoi ne pas remplacer ton champ par une propriété public ?
         public void SetSpeed(float newSpeed)
         {
             _speed = newSpeed;
@@ -43,7 +42,7 @@ namespace Com.Kearny.Shooter.Guns
         {
             var localTransform = transform;
             var ray = new Ray(localTransform.position, localTransform.forward);
-            if (Physics.Raycast(ray, out var hit, moveDistance + SkinWidth, collisionMask, QueryTriggerInteraction.Collide))
+            if (Physics.Raycast(ray, out var hit, moveDistance + SKIN_WIDTH, collisionMask, QueryTriggerInteraction.Collide))
             {
                 OnHitObject(hit.collider, hit.point);
             }
@@ -51,7 +50,7 @@ namespace Com.Kearny.Shooter.Guns
 
         private void OnHitObject(Component colliderComponent, Vector3 hitPoint)
         {
-            colliderComponent.GetComponent<IDamageable>()?.TakeHit(Damage, hitPoint, transform.forward);
+            colliderComponent.GetComponent<IDamageable>()?.TakeHit(DAMAGE, hitPoint, transform.forward);
 
             Destroy(gameObject);
         }

--- a/Assets/Scripts/Com.Kearny.Shooter/Guns/Shell.cs
+++ b/Assets/Scripts/Com.Kearny.Shooter/Guns/Shell.cs
@@ -5,33 +5,39 @@ namespace Com.Kearny.Shooter.Guns
 {
     public class Shell : MonoBehaviour
     {
-        public Rigidbody myRigidbody;
-        public float forceMin;
-        public float forceMax;
-        private Renderer _renderer;
+        /// <summary>
+        /// Lifetime unit is second
+        /// </summary>
+        private const float LIFETIME = 4;
+        /// <summary>
+        /// // Fade time unit is second
+        /// </summary>
+        private const float FADE_TIME = 2;
 
-        private const float Lifetime = 4;
-        private const float FadeTime = 2;
+        public float ForceMin { get; set; }
+        public float ForceMax { get; set; }
+        public Rigidbody Rigidbody { get; set; }
+        public Renderer Renderer { get; set; }
 
         // Start is called before the first frame update
         private void Start()
         {
-            _renderer = GetComponent<Renderer>();
+            Renderer = GetComponent<Renderer>();
             
-            var force = Random.Range(forceMin, forceMax);
-            myRigidbody.AddForce(transform.right * force);
-            myRigidbody.AddTorque(Random.insideUnitSphere * force);
+            var force = Random.Range(ForceMin, ForceMax);
+            Rigidbody.AddForce(transform.right * force);
+            Rigidbody.AddTorque(Random.insideUnitSphere * force);
 
             StartCoroutine(Fade());
         }
 
         private IEnumerator Fade()
         {
-            yield return new WaitForSeconds(Lifetime);
+            yield return new WaitForSeconds(LIFETIME);
 
             float percent = 0;
-            const float fadeSpeed = 1 / FadeTime;
-            Material material = _renderer.material;
+            const float fadeSpeed = 1 / FADE_TIME;
+            Material material = Renderer.material;
             Color initialColor = material.color;
 
             while (percent < 1)

--- a/Assets/Scripts/Com.Kearny.Shooter/Player/Player.cs
+++ b/Assets/Scripts/Com.Kearny.Shooter/Player/Player.cs
@@ -6,16 +6,14 @@ namespace Com.Kearny.Shooter.Player
     [RequireComponent(typeof(PlayerController))]
     public class Player : LivingEntity
     {
+        private PlayerController _controller;
         private Transform _mainCameraTransform;
 
-        public float moveSpeed = 5;
-
-        public float xSensitivity;
-        public float ySensitivity;
-        public float maxAngle = 75f;
-
-        private PlayerController _controller;
-        public Camera mainCamera;
+        public float XSensitivity { get; set; }
+        public float YSensitivity { get; set; }
+        public float MaxAngle { get; set; } = 75f;
+        public float MoveSpeed { get; set; } = 5;
+        public Camera MainCamera { get; set; }
 
         private readonly Quaternion _camCenter = new Quaternion(0, 0, 0, 1);
 
@@ -24,7 +22,7 @@ namespace Com.Kearny.Shooter.Player
         {
             base.Start();
             
-            _mainCameraTransform = mainCamera.transform;
+            _mainCameraTransform = MainCamera.transform;
             _controller = GetComponent<PlayerController>();
         }
 
@@ -38,7 +36,7 @@ namespace Com.Kearny.Shooter.Player
             var localTransform = transform;
             var forwardMovement = localTransform.forward * verticalInput;
             var rightMovement = localTransform.right * horizontalInput;
-            _controller.Move(Vector3.ClampMagnitude(forwardMovement + rightMovement, 1f) * moveSpeed);
+            _controller.Move(Vector3.ClampMagnitude(forwardMovement + rightMovement, 1f) * MoveSpeed);
 
             SetX();
             SetY();
@@ -46,19 +44,19 @@ namespace Com.Kearny.Shooter.Player
 
         private void SetY()
         {
-            var yAngle = Input.GetAxis("Mouse Y") * ySensitivity * Time.deltaTime;
+            var yAngle = Input.GetAxis("Mouse Y") * YSensitivity * Time.deltaTime;
             var xRotation = Quaternion.AngleAxis(yAngle, -Vector3.right);
             var delta = _mainCameraTransform.localRotation * xRotation;
             var angle = Quaternion.Angle(_camCenter, delta);
 
-            if (!(angle > -maxAngle) || !(angle < maxAngle)) return;
+            if (!(angle > -MaxAngle) || !(angle < MaxAngle)) return;
 
             _mainCameraTransform.localRotation = delta;
         }
 
         private void SetX()
         {
-            var yAngle = Input.GetAxis("Mouse X") * xSensitivity * Time.deltaTime;
+            var yAngle = Input.GetAxis("Mouse X") * XSensitivity * Time.deltaTime;
             var xRotation = Quaternion.AngleAxis(yAngle, Vector3.up);
             var delta = transform.localRotation * xRotation;
 


### PR DESCRIPTION
Je t'ai fais quelques exemples d'améliorations de syntaxe de code C#
A toi de voir ce que tu préfères.
Le '_' n'est à utiliser que lorsque tu as un champ privé jamais pour un autre niveau de visibilité.
Les constantes sont toutes en MAJUSCULES_ET_SEPARER_COMME_CA